### PR TITLE
Example upgrade from 0.5 to 0.6

### DIFF
--- a/ads/features/on_demand_feature_views/tests/test_user_query_embedding_similarity.py
+++ b/ads/features/on_demand_feature_views/tests/test_user_query_embedding_similarity.py
@@ -9,7 +9,7 @@ def test_user_query_embedding_similarity():
     request = {'query_embedding': [1.0, 1.0, 0.0]}
     user_embedding = {'user_embedding': [0.0, 1.0, 1.0]}
 
-    actual = user_query_embedding_similarity.local_run(request=request, user_embedding=user_embedding)
+    actual = user_query_embedding_similarity.test_run(request=request, user_embedding=user_embedding)
 
     # Float comparison.
     expected = 0.5

--- a/ads/features/on_demand_feature_views/tests/test_user_query_embedding_similarity.py
+++ b/ads/features/on_demand_feature_views/tests/test_user_query_embedding_similarity.py
@@ -9,7 +9,7 @@ def test_user_query_embedding_similarity():
     request = {'query_embedding': [1.0, 1.0, 0.0]}
     user_embedding = {'user_embedding': [0.0, 1.0, 1.0]}
 
-    actual = user_query_embedding_similarity.run(request=request, user_embedding=user_embedding)
+    actual = user_query_embedding_similarity.local_run(request=request, user_embedding=user_embedding)
 
     # Float comparison.
     expected = 0.5

--- a/ads/features/stream_features/content_keyword_click_counts.py
+++ b/ads/features/stream_features/content_keyword_click_counts.py
@@ -1,4 +1,4 @@
-from tecton import stream_feature_view, FilteredSource, Aggregation, DatabricksClusterConfig, AggregationMode
+from tecton import stream_feature_view, FilteredSource, Aggregation, DatabricksClusterConfig, StreamProcessingMode
 from ads.entities import content_keyword
 from ads.data_sources.ad_impressions import ad_impressions_stream
 from datetime import datetime, timedelta
@@ -13,7 +13,7 @@ cluster_config = DatabricksClusterConfig(
     source=FilteredSource(ad_impressions_stream),
     entities=[content_keyword],
     mode='pyspark',
-    aggregation_mode=AggregationMode.CONTINUOUS, # enable low latency streaming
+    stream_processing_mode=StreamProcessingMode.CONTINUOUS, # enable low latency streaming
     aggregations=[
         Aggregation(column='clicked', function='count', time_window=timedelta(minutes=1)),
         Aggregation(column='clicked', function='count', time_window=timedelta(minutes=5)),

--- a/fraud/features/batch_features/tests/test_user_credit_card_issuer.py
+++ b/fraud/features/batch_features/tests/test_user_credit_card_issuer.py
@@ -1,13 +1,16 @@
+import os
 from datetime import datetime, timedelta
-import pytest
+
 import pandas
+import pytest
+
 from fraud.features.batch_features.user_credit_card_issuer import user_credit_card_issuer
 
 
-# The `tecton_pytest_spark_session` is a PyTest fixture that provides a
-# Tecton-defined PySpark session for testing Spark transformations and feature
-# views.
-@pytest.mark.skip(reason="Requires JDK installation and $JAVA_HOME env variable to run.")
+# The `tecton_pytest_spark_session` is a PyTest fixture that provides a Tecton-defined PySpark session for testing
+# Spark transformations and feature views. This session can be configured as needed by the user. If an entirely new
+# session is needed, then you can create your own and set it with `tecton.set_tecton_spark_session()`.
+@pytest.mark.skipif(os.environ.get("TECTON_TEST_SPARK") is None, reason="Requires JDK installation and $JAVA_HOME env variable to run, so we skip unless user sets the `TECTON_TEST_SPARK` env var.")
 def test_user_credit_card_issuer(tecton_pytest_spark_session):
     input_pandas_df = pandas.DataFrame({
         "user_id": ["user_1", "user_2", "user_3", "user_4"],
@@ -17,12 +20,12 @@ def test_user_credit_card_issuer(tecton_pytest_spark_session):
     input_spark_df = tecton_pytest_spark_session.createDataFrame(input_pandas_df)
 
     # Simulate materializing features for May 1st.
-    output = user_credit_card_issuer.local_run(
+    output = user_credit_card_issuer.test_run(
         start_time=datetime(2022, 5, 1),
         end_time=datetime(2022, 5, 2),
         fraud_users_batch=input_spark_df)
 
-    actual = output.toPandas()
+    actual = output.to_pandas()
 
     expected = pandas.DataFrame({
         "user_id": ["user_1", "user_2", "user_3", "user_4"],
@@ -31,3 +34,10 @@ def test_user_credit_card_issuer(tecton_pytest_spark_session):
     })
 
     pandas.testing.assert_frame_equal(actual, expected)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def configure_spark_session(tecton_pytest_spark_session):
+    # Custom configuration for the spark session. In this case, configure the timezone so that we don't need to specify
+    # a timezone for every datetime in the mock data.
+    tecton_pytest_spark_session.conf.set("spark.sql.session.timeZone", "UTC")

--- a/fraud/features/batch_features/tests/test_user_credit_card_issuer.py
+++ b/fraud/features/batch_features/tests/test_user_credit_card_issuer.py
@@ -17,8 +17,7 @@ def test_user_credit_card_issuer(tecton_pytest_spark_session):
     input_spark_df = tecton_pytest_spark_session.createDataFrame(input_pandas_df)
 
     # Simulate materializing features for May 1st.
-    output = user_credit_card_issuer.run(
-        spark=tecton_pytest_spark_session,
+    output = user_credit_card_issuer.local_run(
         start_time=datetime(2022, 5, 1),
         end_time=datetime(2022, 5, 2),
         fraud_users_batch=input_spark_df)

--- a/fraud/features/batch_features/tests/test_user_distinct_merchant_transaction_count_30d.py
+++ b/fraud/features/batch_features/tests/test_user_distinct_merchant_transaction_count_30d.py
@@ -1,28 +1,36 @@
+import os
 from datetime import datetime, timedelta
-import pytest
+
 import pandas
+import pytest
+
 from fraud.features.batch_features.user_distinct_merchant_transaction_count_30d import user_distinct_merchant_transaction_count_30d
 
 
-# The `tecton_pytest_spark_session` is a PyTest fixture that provides a
-# Tecton-defined PySpark session for testing Spark transformations and feature
-# views.
-@pytest.mark.skip(reason="Requires JDK installation and $JAVA_HOME env variable to run.")
+# The `tecton_pytest_spark_session` is a PyTest fixture that provides a Tecton-defined PySpark session for testing
+# Spark transformations and feature views. This session can be configured as needed by the user. If an entirely new
+# session is needed, then you can create your own and set it with `tecton.set_tecton_spark_session()`.
+@pytest.mark.skipif(os.environ.get("TECTON_TEST_SPARK") is None, reason="Requires JDK installation and $JAVA_HOME env variable to run, so we skip unless user sets the `TECTON_TEST_SPARK` env var.")
 def test_user_distinct_merchant_transaction_count_30d(tecton_pytest_spark_session):
+    timestamps = [datetime(2022, 4, 10), datetime(2022, 4, 25), datetime(2022, 5, 1)]
     input_pandas_df = pandas.DataFrame({
         "user_id": ["user_1", "user_1", "user_2"],
         "merchant": ["merchant_1", "merchant_2", "merchant_1"],
-        "timestamp": [datetime(2022, 4, 10), datetime(2022, 4, 25), datetime(2022, 5, 1)],
+        "timestamp": timestamps,
+        "partition_0": [ts.year for ts in timestamps],
+        "partition_1": [ts.month for ts in timestamps],
+        "partition_2": [ts.day for ts in timestamps],
     })
     input_spark_df = tecton_pytest_spark_session.createDataFrame(input_pandas_df)
 
     # Simulate materializing features for May 1st.
-    output = user_distinct_merchant_transaction_count_30d.local_run(
+    output = user_distinct_merchant_transaction_count_30d.test_run(
         start_time=datetime(2022, 5, 1),
         end_time=datetime(2022, 5, 2),
-        transactions_batch=input_spark_df)
+        transactions_batch=input_spark_df
+    )
 
-    actual = output.toPandas()
+    actual = output.to_pandas()
 
     expected = pandas.DataFrame({
         "user_id": ["user_1", "user_2"],
@@ -31,3 +39,10 @@ def test_user_distinct_merchant_transaction_count_30d(tecton_pytest_spark_sessio
     })
 
     pandas.testing.assert_frame_equal(actual, expected)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def configure_spark_session(tecton_pytest_spark_session):
+    # Custom configuration for the spark session. In this case, configure the timezone so that we don't need to specify
+    # a timezone for every datetime in the mock data.
+    tecton_pytest_spark_session.conf.set("spark.sql.session.timeZone", "UTC")

--- a/fraud/features/batch_features/tests/test_user_distinct_merchant_transaction_count_30d.py
+++ b/fraud/features/batch_features/tests/test_user_distinct_merchant_transaction_count_30d.py
@@ -17,8 +17,7 @@ def test_user_distinct_merchant_transaction_count_30d(tecton_pytest_spark_sessio
     input_spark_df = tecton_pytest_spark_session.createDataFrame(input_pandas_df)
 
     # Simulate materializing features for May 1st.
-    output = user_distinct_merchant_transaction_count_30d.run(
-        spark=tecton_pytest_spark_session,
+    output = user_distinct_merchant_transaction_count_30d.local_run(
         start_time=datetime(2022, 5, 1),
         end_time=datetime(2022, 5, 2),
         transactions_batch=input_spark_df)

--- a/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_high.py
+++ b/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_high.py
@@ -15,5 +15,5 @@ def test_transaction_amount_is_high(amount, expected):
     transaction_request = {'amt': amount}
     expected = {'transaction_amount_is_high': expected}
 
-    actual = transaction_amount_is_high.run(transaction_request=transaction_request)
+    actual = transaction_amount_is_high.local_run(transaction_request=transaction_request)
     assert expected == actual

--- a/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_high.py
+++ b/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_high.py
@@ -15,5 +15,5 @@ def test_transaction_amount_is_high(amount, expected):
     transaction_request = {'amt': amount}
     expected = {'transaction_amount_is_high': expected}
 
-    actual = transaction_amount_is_high.local_run(transaction_request=transaction_request)
+    actual = transaction_amount_is_high.test_run(transaction_request=transaction_request)
     assert expected == actual

--- a/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_higher_than_average.py
+++ b/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_higher_than_average.py
@@ -15,7 +15,7 @@ def test_transaction_amount_is_higher_than_average(daily_mean, amount, expected)
     user_transaction_amount_metrics = {'amt_mean_1d_10m': daily_mean}
     transaction_request = {'amt': amount}
 
-    actual = transaction_amount_is_higher_than_average.run(
+    actual = transaction_amount_is_higher_than_average.local_run(
         transaction_request=transaction_request,
         user_transaction_amount_metrics=user_transaction_amount_metrics)
 

--- a/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_higher_than_average.py
+++ b/fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_higher_than_average.py
@@ -15,7 +15,7 @@ def test_transaction_amount_is_higher_than_average(daily_mean, amount, expected)
     user_transaction_amount_metrics = {'amt_mean_1d_10m': daily_mean}
     transaction_request = {'amt': amount}
 
-    actual = transaction_amount_is_higher_than_average.local_run(
+    actual = transaction_amount_is_higher_than_average.test_run(
         transaction_request=transaction_request,
         user_transaction_amount_metrics=user_transaction_amount_metrics)
 

--- a/fraud/features/on_demand_feature_views/tests/test_user_age.py
+++ b/fraud/features/on_demand_feature_views/tests/test_user_age.py
@@ -7,6 +7,6 @@ def test_user_age():
     user_date_of_birth = {'USER_DATE_OF_BIRTH': '1992-12-05'}
     request = {'timestamp': '2021-05-14T00:00:00.000+00:00'}
 
-    actual = user_age.local_run(request=request, user_date_of_birth=user_date_of_birth)
+    actual = user_age.test_run(request=request, user_date_of_birth=user_date_of_birth)
     expected = {'user_age': 10387}
     assert actual == expected

--- a/fraud/features/on_demand_feature_views/tests/test_user_age.py
+++ b/fraud/features/on_demand_feature_views/tests/test_user_age.py
@@ -7,6 +7,6 @@ def test_user_age():
     user_date_of_birth = {'USER_DATE_OF_BIRTH': '1992-12-05'}
     request = {'timestamp': '2021-05-14T00:00:00.000+00:00'}
 
-    actual = user_age.run(request=request, user_date_of_birth=user_date_of_birth)
+    actual = user_age.local_run(request=request, user_date_of_birth=user_date_of_birth)
     expected = {'user_age': 10387}
     assert actual == expected

--- a/fraud/features/stream_features/last_transactions.py
+++ b/fraud/features/stream_features/last_transactions.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
     aggregation_interval=timedelta(minutes=10),  # Defines how frequently feature values get updated in the online store
     batch_schedule=timedelta(days=1), # Defines how frequently batch jobs are scheduled to ingest into the offline store
     aggregations=[
-        Aggregation(column='amt', function=last_distinct(10), time_window=timedelta(hours=1))
+        Aggregation(column='amt', function=last_distinct(10), time_window=timedelta(hours=1), name="amt_lastn10_1h_10m")
     ],
     online=False,
     offline=False,

--- a/fraud/features/stream_features/user_continuous_transaction_count.py
+++ b/fraud/features/stream_features/user_continuous_transaction_count.py
@@ -1,4 +1,4 @@
-from tecton import stream_feature_view, FilteredSource, Aggregation, AggregationMode
+from tecton import stream_feature_view, FilteredSource, Aggregation, StreamProcessingMode
 from fraud.entities import user
 from fraud.data_sources.transactions import transactions_stream
 from datetime import datetime, timedelta
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
     source=FilteredSource(transactions_stream),
     entities=[user],
     mode='spark_sql',
-    aggregation_mode=AggregationMode.CONTINUOUS,
+    stream_processing_mode=StreamProcessingMode.CONTINUOUS,
     aggregations=[
         Aggregation(column='transaction', function='count', time_window=timedelta(minutes=1)),
         Aggregation(column='transaction', function='count', time_window=timedelta(minutes=30)),


### PR DESCRIPTION
Example upgrade from SDK v0.5 to v0.6.

Produces the following plan diff:

```
$ tecton plan
Using workspace "jake_0_5" on cluster https://staging.tecton.ai
✅ Imported 47 Python modules from the feature repository
✅ Imported 47 Python modules from the feature repository
🏃 Running Tests
==================================================================================================== test session starts =====================================================================================================
platform darwin -- Python 3.9.11, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jdnoble/repos/sample_repo
plugins: tecton-99.99.99, typeguard-2.13.3, anyio-3.6.2
collected 10 items

ads/features/on_demand_feature_views/tests/test_user_query_embedding_similarity.py .
fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_higher_than_average.py ...
fraud/features/on_demand_feature_views/tests/test_user_age.py .
fraud/features/on_demand_feature_views/tests/test_transaction_amount_is_high.py ...
fraud/features/batch_features/tests/test_user_credit_card_issuer.py s
fraud/features/batch_features/tests/test_user_distinct_merchant_transaction_count_30d.py s

========================================================================================== 8 passed, 2 skipped, 8 warnings in 0.04s ==========================================================================================
✅ Running Tests: Tests passed!
✅ Collecting local feature declarations
✅ Performing server-side feature validation: Finished generating plan.
 ↓↓↓↓↓↓↓↓↓↓↓↓ Plan Start ↓↓↓↓↓↓↓↓↓↓

  ~ Upgrade Transformation
    name:           user_distinct_ad_count_7d
    owner:          david@tecton.ai
    description:    How many distinct advertisements a user has been shown in the last week
    user_function.body:
    -from tecton_spark.materialization_context import materialization_context
    +from tecton_core.materialization_context import materialization_context
     def user_distinct_ad_count_7d(ad_impressions, context=materialization_context()):
         return f'''
             SELECT
                 user_uuid as user_id,

  ~ Upgrade Transformation
    name:           user_distinct_merchant_transaction_count_30d
    owner:          david@tecton.ai
    description:    How many transactions the user has made to distinct merchants in the last 30 days.
    user_function.body:
    -from tecton_spark.materialization_context import materialization_context
    +from tecton_core.materialization_context import materialization_context
     def user_distinct_merchant_transaction_count_30d(transactions_batch, context=materialization_context()):
         return f'''
             SELECT
                 user_id,

  ~ Update Feature Table
    name:           ad_embeddings
    owner:          jake@tecton.ai
    description:    Precomputed ad embeddings pushed into Tecton.
    warning:        Changing spark version for batch materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Feature Table
    name:           user_embeddings
    owner:          jake@tecton.ai
    description:    Precomputed user embeddings pushed into Tecton.
    warning:        Changing spark version for batch materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           content_keyword_click_counts
    owner:          ravi@tecton.ai
    description:    The count of ad impressions for a content_keyword
    batch_compute.new_databricks.pinned_spark_version:  -> 10.4.x-scala2.12
    stream_compute.new_databricks.pinned_spark_version:  -> 10.4.x-scala2.12
    warning:        Changing spark version for batch materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           user_ad_impression_counts
    owner:          matt@tecton.ai
    description:    The count of impressions between a given user and a given ad
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           user_click_counts
    owner:          matt@tecton.ai
    description:    The count of ad clicks for a user
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           user_impression_counts
    owner:          matt@tecton.ai
    description:    The count of ad impressions for a user
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Feature Table
    name:           user_login_counts
    owner:          derek@tecton.ai
    description:    User login counts over time.
    warning:        Changing spark version for batch materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           user_transaction_amount_metrics
    owner:          kevin@tecton.ai
    description:    Transaction amount statistics and total over a series of time windows, updated every 10 minutes.
    warning:        This Feature View creates a stream job, but does not specify a stream_compute. Use the stream_compute to tune resources for your workload and avoid unnecessary costs.
    warning:        This Feature View has online materialization enabled, but does not have monitoring configured. Use the `monitor_freshness` and `alert_email` fields to be alerted if there are issues with the materialization jobs.
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           last_transaction_amount_pyspark
    description:    Last user transaction amount (stream calculated)
    warning:        This Feature View has materialization enabled, but no owner. Specifying an owner will provide a point of contact in case of an issue.
    warning:        This Feature View uses Data sources(s) `transactions_stream` which has `date_time_partitions` set, however the source(s) need to be wrapped in `FilteredSource` in Feature View definition to use this partitioning to optimize queries. To avoid re-materializing your Feature View data, you can run `tecton apply --suppress-recreates` when making this change.
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           user_continuous_transaction_count
    owner:          david@tecton.ai
    description:    Number of transactions a user has made recently
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           user_recent_transactions
    owner:          kevin@tecton.ai
    description:    Most recent 10 transaction amounts of a user
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

  ~ Update Stream Feature View
    name:           last_transaction_amount_sql
    description:    Last user transaction amount (stream calculated)
    warning:        This Feature View has materialization enabled, but no owner. Specifying an owner will provide a point of contact in case of an issue.
    warning:        This Feature View uses Data sources(s) `transactions_stream` which has `date_time_partitions` set, however the source(s) need to be wrapped in `FilteredSource` in Feature View definition to use this partitioning to optimize queries. To avoid re-materializing your Feature View data, you can run `tecton apply --suppress-recreates` when making this change.
    warning:        Changing spark version for stream materialization from 9.1.x-scala2.12 to 10.4.x-scala2.12. Though uncommon, feature computation behavior could change across different versions. Read this guide for additional details: https://docs.tecton.ai/latest/setting-up-tecton/11-upgrade-spark.html

 ↑↑↑↑↑↑↑↑↑↑↑↑ Plan End ↑↑↑↑↑↑↑↑↑↑↑↑
 Generated plan ID is 48d2fd81f20648c1becd4bdb55889043
 View your plan in the Web UI: https://staging.tecton.ai/app/jake_0_5/plan-summary/48d2fd81f20648c1becd4bdb55889043
 ⚠️  Objects in plan contain warnings.
```